### PR TITLE
CSP-1818: Accessibility - Provider Relationships (Provider-Led) - Redundant Cancel link

### DIFF
--- a/src/SFA.DAS.Provider.PR.Web.UnitTests/Controllers/SearchByEmail/SearchByEmailControllerGetTests.cs
+++ b/src/SFA.DAS.Provider.PR.Web.UnitTests/Controllers/SearchByEmail/SearchByEmailControllerGetTests.cs
@@ -15,7 +15,6 @@ namespace SFA.DAS.Provider.PR_Web.UnitTests.Controllers.SearchByEmail;
 public class SearchByEmailControllerGetTests
 {
     private static readonly string BackLink = Guid.NewGuid().ToString();
-    private static readonly string CancelLink = BackLink;
     private static readonly string CheckDetailsLink = Guid.NewGuid().ToString();
 
     [Test, MoqAutoData]
@@ -33,7 +32,6 @@ public class SearchByEmailControllerGetTests
         SearchByEmailModel? viewModel = viewResult.Model as SearchByEmailModel;
         viewModel!.Ukprn.Should().Be(ukprn);
         viewModel.BackLink.Should().Be(BackLink);
-        viewModel.CancelLink.Should().Be(CancelLink);
         viewModel.Email.Should().BeNull();
     }
 
@@ -56,7 +54,6 @@ public class SearchByEmailControllerGetTests
         SearchByEmailModel? viewModel = viewResult.Model as SearchByEmailModel;
         viewModel!.Ukprn.Should().Be(ukprn);
         viewModel.BackLink.Should().Be(BackLink);
-        viewModel.CancelLink.Should().Be(CancelLink);
         viewModel.Email.Should().Be(email);
     }
 

--- a/src/SFA.DAS.Provider.PR.Web.UnitTests/Controllers/SearchByEmail/SearchByEmailControllerPostTests.cs
+++ b/src/SFA.DAS.Provider.PR.Web.UnitTests/Controllers/SearchByEmail/SearchByEmailControllerPostTests.cs
@@ -219,17 +219,17 @@ public class SearchByEmailControllerPostTests
         var result = await sut.Index(ukprn, searchByEmailSubmitModel, cancellationToken);
 
         var viewResult = result.As<ViewResult>();
-        Assert.IsNotNull(viewResult);
+        Assert.That(viewResult, Is.Not.Null);
 
         var viewModel = viewResult.Model as SearchByEmailModel;
-        Assert.IsNotNull(viewModel);
+        Assert.That(viewModel, Is.Not.Null);
 
         Assert.Multiple(() =>
         {
             Assert.That(viewModel!.Email, Is.Null);
 
             var emailError = viewResult.ViewData.ModelState["Email"]?.Errors.FirstOrDefault();
-            Assert.IsNotNull(emailError, "Expected a validation error for the 'Email' field.");
+            Assert.That(emailError, Is.Not.Null, "Expected a validation error for the 'Email' field.");
             Assert.That(emailError!.ErrorMessage, Is.EqualTo("Email field is invalid"));
         });
     }

--- a/src/SFA.DAS.Provider.PR.Web.UnitTests/Controllers/SearchByEmail/SearchByEmailControllerPostTests.cs
+++ b/src/SFA.DAS.Provider.PR.Web.UnitTests/Controllers/SearchByEmail/SearchByEmailControllerPostTests.cs
@@ -19,7 +19,6 @@ namespace SFA.DAS.Provider.PR_Web.UnitTests.Controllers.SearchByEmail;
 public class SearchByEmailControllerPostTests
 {
     private static readonly string BackLink = Guid.NewGuid().ToString();
-    private static readonly string CancelLink = BackLink;
     private static readonly string RedirectToMultipleAccountsShutterPage = Guid.NewGuid().ToString();
     private static readonly string EmailSearchInviteAlreadySentPage = Guid.NewGuid().ToString();
 
@@ -191,7 +190,6 @@ public class SearchByEmailControllerPostTests
         SearchByEmailModel? viewModel = viewResult.Model as SearchByEmailModel;
         viewModel!.Ukprn.Should().Be(ukprn);
         viewModel.BackLink.Should().Be(BackLink);
-        viewModel.CancelLink.Should().Be(CancelLink);
         viewModel.Email.Should().Be(Email);
     }
 

--- a/src/SFA.DAS.Provider.PR.Web/Controllers/AddEmployer/SearchByEmailController.cs
+++ b/src/SFA.DAS.Provider.PR.Web/Controllers/AddEmployer/SearchByEmailController.cs
@@ -49,18 +49,18 @@ public class SearchByEmailController(IOuterApiClient _outerApiClient, ISessionSe
     [HttpPost]
     public async Task<IActionResult> Index([FromRoute] int ukprn, SearchByEmailSubmitModel submitModel, CancellationToken cancellationToken)
     {
-        submitModel.Email = submitModel.Email!.Trim();
+        submitModel.Email = submitModel.Email?.Trim();
         var result = _validator.Validate(submitModel);
 
         if (!result.IsValid)
         {
             var viewModel = GetViewModel(ukprn);
-            viewModel.Email = submitModel.Email!.Trim();
+            viewModel.Email = submitModel.Email?.Trim();
             result.AddToModelState(ModelState);
             return View(ViewPath, viewModel);
         }
 
-        var sessionModel = new AddEmployerSessionModel { Email = submitModel.Email };
+        var sessionModel = new AddEmployerSessionModel { Email = submitModel.Email! };
         _sessionService.Set(sessionModel);
 
 

--- a/src/SFA.DAS.Provider.PR.Web/Controllers/AddEmployer/SearchByEmailController.cs
+++ b/src/SFA.DAS.Provider.PR.Web/Controllers/AddEmployer/SearchByEmailController.cs
@@ -190,9 +190,8 @@ public class SearchByEmailController(IOuterApiClient _outerApiClient, ISessionSe
 
     private SearchByEmailModel GetViewModel(int ukprn)
     {
-        var cancelLink = Url.RouteUrl(RouteNames.AddEmployerStart, new { ukprn });
         var backLink = Url.RouteUrl(RouteNames.AddEmployerStart, new { ukprn });
-        return new SearchByEmailModel { CancelLink = cancelLink!, BackLink = backLink!, Ukprn = ukprn };
+        return new SearchByEmailModel { BackLink = backLink!, Ukprn = ukprn };
     }
 
     private static bool HasMultipleAccounts(GetRelationshipByEmailResponse response)

--- a/src/SFA.DAS.Provider.PR.Web/Models/AddEmployer/SearchByEmailViewModel.cs
+++ b/src/SFA.DAS.Provider.PR.Web/Models/AddEmployer/SearchByEmailViewModel.cs
@@ -4,10 +4,8 @@ public class SearchByEmailModel : SearchByEmailSubmitModel
 {
     public SearchByEmailModel() { }
 
-    public required string CancelLink { get; init; }
     public required string BackLink { get; init; }
     public required long Ukprn { get; init; }
-
 }
 
 public class SearchByEmailSubmitModel

--- a/src/SFA.DAS.Provider.PR.Web/Views/AddEmployer/SearchByEmail.cshtml
+++ b/src/SFA.DAS.Provider.PR.Web/Views/AddEmployer/SearchByEmail.cshtml
@@ -32,10 +32,10 @@
             <div esfa-validation-marker-for="@Model.Email" class="govuk-form-group">
                 <span asp-validation-for="Email" class="govuk-error-message"></span>
                 <div class="govuk-body" id="email">
-                    <label class="govuk-label" for="email">
+                    <label id="email-label" class="govuk-label" for="email-input">
                         <strong>Employer email address</strong>
                     </label>
-                    <input asp-for="Email" class="govuk-input"  name="email" type="text" spellcheck="false" aria-describedby="email-hint" autocomplete="email" sfa-validationerror-class="form-control-error" maxlength="254">
+                    <input id="email-input" asp-for="Email" class="govuk-input" name="email" type="text" spellcheck="false" aria-describedby="email-label" autocomplete="email" sfa-validationerror-class="form-control-error" maxlength="254">
                 </div>
             </div>
             <div class="govuk-button-group">

--- a/src/SFA.DAS.Provider.PR.Web/Views/AddEmployer/SearchByEmail.cshtml
+++ b/src/SFA.DAS.Provider.PR.Web/Views/AddEmployer/SearchByEmail.cshtml
@@ -40,7 +40,6 @@
             </div>
             <div class="govuk-button-group">
                 <button type="submit" id="continue" class="govuk-button" data-disable-on-submit="true">Search</button>
-                <a class="govuk-link" href="@Model.CancelLink">Cancel</a>
             </div>
         </form>
     </div>

--- a/src/SFA.DAS.Provider.PR.Web/Views/AddEmployer/SearchByEmail.cshtml
+++ b/src/SFA.DAS.Provider.PR.Web/Views/AddEmployer/SearchByEmail.cshtml
@@ -31,11 +31,11 @@
             <input asp-for="Ukprn" id="Ukprn" type="hidden" />
             <div esfa-validation-marker-for="@Model.Email" class="govuk-form-group">
                 <span asp-validation-for="Email" class="govuk-error-message"></span>
-                <div class="govuk-body" id="email">
-                    <label id="email-label" class="govuk-label" for="email-input">
+                <div class="govuk-body">
+                    <label id="EmailLabel" class="govuk-label" for="Email">
                         <strong>Employer email address</strong>
                     </label>
-                    <input id="email-input" asp-for="Email" class="govuk-input" name="email" type="text" spellcheck="false" aria-describedby="email-label" autocomplete="email" sfa-validationerror-class="form-control-error" maxlength="254">
+                    <input id="Email" asp-for="Email" class="govuk-input" name="email" type="text" spellcheck="false" aria-describedby="EmailLabel" autocomplete="email" sfa-validationerror-class="form-control-error" maxlength="254">
                 </div>
             </div>
             <div class="govuk-button-group">


### PR DESCRIPTION
- Remove redundant cancel link from the **SearchByEmail** view as well as all associated code references.
- Also incorporates **CSP-1817** - Added associated label reference to search by email input.