### PR TITLE
CSP-1847 - Added resilience to Employer Details controller

### DIFF
--- a/src/SFA.DAS.Provider.PR.Domain/Interfaces/IOuterApiClient.cs
+++ b/src/SFA.DAS.Provider.PR.Domain/Interfaces/IOuterApiClient.cs
@@ -40,6 +40,11 @@ public interface IOuterApiClient
     Task<Response<GetRequestByUkprnEmailResponse>> GetRequestByUkprnAndEmail([Query] long ukprn, [Query] string email, CancellationToken cancellationToken);
 
     [AllowAnyStatusCode]
+    [Get("requests")]
+    Task<Response<GetRequestByUkprnAccountLegalEntityIdResponse>> GetRequestByUkprnAndAccountLegalEntityId(
+        [Query] long ukprn, [Query] long accountLegalEntityId, CancellationToken cancellationToken);
+
+    [AllowAnyStatusCode]
     [Get("requests/{requestid}")]
     Task<Response<GetRequestsByRequestIdResponse>> GetRequestByRequestId([Path] Guid requestid, CancellationToken cancellationToken);
 }

--- a/src/SFA.DAS.Provider.PR.Domain/OuterApi/Responses/GetRequestByUkprnAccountLegalEntityIdResponse.cs
+++ b/src/SFA.DAS.Provider.PR.Domain/OuterApi/Responses/GetRequestByUkprnAccountLegalEntityIdResponse.cs
@@ -1,0 +1,9 @@
+﻿namespace SFA.DAS.Provider.PR.Domain.OuterApi.Responses;
+public class GetRequestByUkprnAccountLegalEntityIdResponse
+{
+    public Guid? RequestId { get; set; }
+
+    public RequestStatus? Status { get; set; }
+
+    public RequestType RequestType { get; set; }
+}

--- a/src/SFA.DAS.Provider.PR.Web.UnitTests/Controllers/EmployerDetailsControllerTests.cs
+++ b/src/SFA.DAS.Provider.PR.Web.UnitTests/Controllers/EmployerDetailsControllerTests.cs
@@ -26,8 +26,8 @@ public class EmployerDetailsControllerTests
 
         Mock<IOuterApiClient> outerApiClientMock = new();
         outerApiClientMock.Setup(x =>
-                x.GetRequestByUkprnAndAccountLegalEntityId(ukprn, accountLegalEntityId, CancellationToken.None))
-            .ReturnsAsync((Response<GetRequestByUkprnAccountLegalEntityIdResponse>)null);
+                x.GetRequestByUkprnAndAccountLegalEntityId(ukprn, accountLegalEntityId, CancellationToken.None))!
+            .ReturnsAsync(new Response<GetRequestByUkprnAccountLegalEntityIdResponse>(null, new(HttpStatusCode.OK), () => ((GetRequestByUkprnAccountLegalEntityIdResponse?)null)!));
 
         outerApiClientMock.Setup(x => x.GetProviderRelationship(ukprn, accountLegalEntityId, CancellationToken.None))
             .ReturnsAsync(response);
@@ -57,8 +57,8 @@ public class EmployerDetailsControllerTests
 
         Mock<IOuterApiClient> outerApiClientMock = new();
         outerApiClientMock.Setup(x =>
-                x.GetRequestByUkprnAndAccountLegalEntityId(ukprn, accountLegalEntityId, CancellationToken.None))
-            .ReturnsAsync((Response<GetRequestByUkprnAccountLegalEntityIdResponse>)null);
+                x.GetRequestByUkprnAndAccountLegalEntityId(ukprn, accountLegalEntityId, CancellationToken.None))!
+            .ReturnsAsync(new Response<GetRequestByUkprnAccountLegalEntityIdResponse>(null, new(HttpStatusCode.OK), () => ((GetRequestByUkprnAccountLegalEntityIdResponse?)null)!));
 
         outerApiClientMock.Setup(x => x.GetProviderRelationship(ukprn, accountLegalEntityId, CancellationToken.None))
             .ReturnsAsync(response);

--- a/src/SFA.DAS.Provider.PR.Web.UnitTests/Models/EmployerDetailsViewModelTests.cs
+++ b/src/SFA.DAS.Provider.PR.Web.UnitTests/Models/EmployerDetailsViewModelTests.cs
@@ -83,8 +83,6 @@ public class EmployerDetailsViewModelTests
     [Test, AutoData]
     public void ModelIsCreatedCorrectly_FromGetRequestsByRequestIdResponseObject(GetRequestsByRequestIdResponse response)
     {
-        response.AccountLegalEntityId = null;
-
         var actual = (EmployerDetailsViewModel)response;
 
         Assert.Multiple(() =>
@@ -97,7 +95,7 @@ public class EmployerDetailsViewModelTests
             Assert.That(actual.LastRequestOperations, Is.EqualTo(response.Operations));
             Assert.That(actual.HasPermissionsRequest, Is.True);
             Assert.That(actual.HasExistingPermissions, Is.False);
-            Assert.That(actual.ShowAgreementId, Is.False);
+            Assert.That(actual.ShowAgreementId, Is.True);
         });
     }
 

--- a/src/SFA.DAS.Provider.PR.Web/Controllers/EmployerDetailsController.cs
+++ b/src/SFA.DAS.Provider.PR.Web/Controllers/EmployerDetailsController.cs
@@ -21,6 +21,19 @@ public class EmployerDetailsController(IOuterApiClient _outerApiclient, IEncodin
     {
         var accountLegalEntityIdDecoded = encodingService.Decode(accountlegalentityid, EncodingType.PublicAccountLegalEntityId);
 
+        var requestResponse =
+            await _outerApiclient.GetRequestByUkprnAndAccountLegalEntityId(ukprn, accountLegalEntityIdDecoded,
+                cancellationToken);
+        var request = requestResponse?.GetContent();
+
+        if (request?.RequestId != null &&
+            request?.RequestId != Guid.Empty &&
+            request?.RequestType == RequestType.AddAccount &&
+           (request?.Status == RequestStatus.New || request?.Status == RequestStatus.Sent))
+        {
+            return RedirectToRoute(RouteNames.EmployerDetailsByRequestId, new { ukprn, request.RequestId });
+        }
+
         GetProviderRelationshipResponse response =
             await _outerApiclient.GetProviderRelationship(ukprn, accountLegalEntityIdDecoded, cancellationToken);
 

--- a/src/SFA.DAS.Provider.PR.Web/Controllers/EmployerDetailsController.cs
+++ b/src/SFA.DAS.Provider.PR.Web/Controllers/EmployerDetailsController.cs
@@ -27,9 +27,9 @@ public class EmployerDetailsController(IOuterApiClient _outerApiclient, IEncodin
         var request = requestResponse?.GetContent();
 
         if (request?.RequestId != null &&
-            request?.RequestId != Guid.Empty &&
-            request?.RequestType == RequestType.AddAccount &&
-           (request?.Status == RequestStatus.New || request?.Status == RequestStatus.Sent))
+            request.RequestId != Guid.Empty &&
+            request.RequestType == RequestType.AddAccount &&
+           (request.Status == RequestStatus.New || request.Status == RequestStatus.Sent))
         {
             return RedirectToRoute(RouteNames.EmployerDetailsByRequestId, new { ukprn, request.RequestId });
         }

--- a/src/SFA.DAS.Provider.PR.Web/Models/EmployerDetailsViewModel.cs
+++ b/src/SFA.DAS.Provider.PR.Web/Models/EmployerDetailsViewModel.cs
@@ -71,6 +71,7 @@ public class EmployerDetailsViewModel
     {
         return new EmployerDetailsViewModel
         {
+            AccountLegalEntityId = (long)response.AccountLegalEntityId!,
             AccountLegalEntityName = response.EmployerOrganisationName!.ToUpper(),
             Ukprn = response.Ukprn,
             LastActionDate = response.RequestedDate.ToString("d MMM yyyy"),


### PR DESCRIPTION
Updated Employer details controller to redirect to using request id instead of account legal entity id when there is an active add account request.